### PR TITLE
The route will load if query or params get updated

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,12 +11,13 @@ exports.sync = function (store, router) {
       return state.route
     },
     function (route) {
-      if (route.path === currentPath) {
-        return
-      }
       isTimeTraveling = true
       currentPath = route.path
-      router.go(route.path)
+      router.go({
+        path: route.path,
+        query: route.query,
+        params: route.params
+      })
     },
     { deep: true, sync: true }
   )


### PR DESCRIPTION
I have routes as follows:

`products?limit=100`

When the `limit` updates, I make an api request which grabs 100 records (or however many the limit is set to). I need to do this on the route `data` transition step.

When updating the `query` on the `route` state, the state would update but not the route itself. The route would only update if the path changes which isn't ideal when you rely on `query` or `params`.

This fixes that - not sure if you want to merge this but thought I'd make a pull request anyway as I'm quite new to this.

Cheers!
