### PR TITLE
Fixes a first-run redirect error

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ exports.sync = function (store, router) {
       isTimeTraveling = false
       return
     }
-    var to = transition.to
+    var to = transition.to || transition
     currentPath = to.path
     commit('router/ROUTE_CHANGED', to)
   })


### PR DESCRIPTION
Basically I get a `Cannot read property 'path' of undefined` when the page first loads when it starts by redirecting. More importantly, I must be doing something wrong because `transition` (which is a route instance) never seems to have a `to` property; I scoured the current version of vue-router and couldn't find anything like that (perhaps this is a vestige of Vue 1's router, which I never used?).
