### PR TITLE
Fix typescript declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,4 +5,4 @@ interface SyncOptions {
   moduleName: string;
 }
 
-export declare function sync(store: Store<any>, router: VueRouter, options?: SyncOptions);
+export declare function sync(store: Store<any>, router: VueRouter, options?: SyncOptions): void;


### PR DESCRIPTION
I got this error if I set `"noImplicitAny": true`

`(8,25): error TS7010: 'sync', which lacks return-type annotation, implicitly has an 'any' return type.`