### PR TITLE
Provide a way to un-sync (#64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,13 @@ import { sync } from 'vuex-router-sync'
 import store from './vuex/store' // vuex store instance
 import router from './router' // vue-router instance
 
-sync(store, router) // done.
+const unsync = sync(store, router) // done. Returns an unsync callback fn
 
 // bootstrap your app...
+
+// During app/Vue teardown (e.g., you only use Vue.js in a portion of your app and you 
+// navigate away from that portion and want to release/destroy Vue components/resources)
+unsync() // Unsyncs store from router
 ```
 
 You can optionally set a custom vuex module name:
@@ -27,7 +31,6 @@ You can optionally set a custom vuex module name:
 ```js
 sync(store, router, { moduleName: 'RouteModule' } )
 ```
-
 
 ### How does it work?
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ exports.sync = function (store, router, options) {
   var currentPath
 
   // sync router on store change
-  store.watch(
+  const storeUnwatch = store.watch(
     function (state) { return state[moduleName] },
     function (route) {
       if (route.fullPath === currentPath) {
@@ -32,7 +32,7 @@ exports.sync = function (store, router, options) {
   )
 
   // sync store on router navigation
-  router.afterEach(function (to, from) {
+  const afterEachUnHook = router.afterEach(function (to, from) {
     if (isTimeTraveling) {
       isTimeTraveling = false
       return
@@ -40,6 +40,21 @@ exports.sync = function (store, router, options) {
     currentPath = to.fullPath
     store.commit(moduleName + '/ROUTE_CHANGED', { to: to, from: from })
   })
+
+  return function unsync() {
+    // On unsync, remove router hook
+    if (afterEachUnHook != null) {
+      afterEachUnHook()
+    }
+    
+    // On unsync, remove store watch
+    if (storeUnwatch != null) {
+      storeUnwatch();
+    }
+
+    // On unsync, unregister Module with store
+    store.unregisterModule(moduleName)
+  }
 }
 
 function cloneRoute (to, from) {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "vuex": "^2.1.0"
   },
   "peerDependencies": {
-    "vue-router": "^2.0.0",
+    "vue-router": "^2.5.0",
     "vuex": "^2.1.0"
   }
 }


### PR DESCRIPTION
Currently, vuex-router-sync only publicly exposes a single method: ‘sync’.  This method creates a store.watch as well as a router.beforeHook.  No publicly available method existed to effectively ‘unsync’ vuex-router-sync and remove the watch and hook, which created ‘dangling’ refrences and a potential memory leak.  Users of this library may need an ‘unsync’ function if they, for example, only use Vue.js in specific portions of their webapp (e.g. with React, Angular, etc.) and when users navigate away from that portion they want to remove/clean-up all Vue.js resources and components.  Includes a unit test.  Had to bump vue-router to version 2.5.0 which was the first version to allow de-registering hook functions.