### PR TITLE
fix: clone route outside of mutation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,8 @@ exports.sync = function (store, router, options) {
     namespaced: true,
     state: cloneRoute(router.currentRoute),
     mutations: {
-      'ROUTE_CHANGED' (state, transition) {
-        store.state[moduleName] = cloneRoute(transition.to, transition.from)
+      'ROUTE_CHANGED' (state, route) {
+        store.state[moduleName] = route;
       }
     }
   })
@@ -38,7 +38,7 @@ exports.sync = function (store, router, options) {
       return
     }
     currentPath = to.fullPath
-    store.commit(moduleName + '/ROUTE_CHANGED', { to, from })
+    store.commit(moduleName + '/ROUTE_CHANGED', cloneRoute(to, from))
   })
 
   return function unsync () {


### PR DESCRIPTION
This change moves to call to `cloneRoute` outside of the mutation and passes the already-cloned route as the payload. It fixes some console errors that might occur when the vue-devtools extension tries to clone the mutation payload. In my case there were errors when it attempted to clone components within the `matched` array of the route.