### PR TITLE
refactor: sync store on beforeEach instead

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,19 +32,20 @@ exports.sync = function (store, router, options) {
   )
 
   // sync store on router navigation
-  const afterEachUnHook = router.afterEach((to, from) => {
+  const beforeEachUnhook = router.beforeEach((to, from, next) => {
     if (isTimeTraveling) {
       isTimeTraveling = false
       return
     }
     currentPath = to.fullPath
     store.commit(moduleName + '/ROUTE_CHANGED', { to, from })
+    next()
   })
 
   return function unsync () {
     // On unsync, remove router hook
-    if (afterEachUnHook != null) {
-      afterEachUnHook()
+    if (beforeEachUnhook != null) {
+      beforeEachUnhook()
     }
 
     // On unsync, remove store watch

--- a/test/test.js
+++ b/test/test.js
@@ -87,14 +87,14 @@ test('unsync', done => {
   expect(store._watcherVM).toBeDefined()
   expect(store._watcherVM._watchers).toBeDefined()
   expect(store._watcherVM._watchers.length).toBe(1)
-  expect(router.afterHooks).toBeDefined()
-  expect(router.afterHooks.length).toBe(1)
+  expect(router.beforeHooks).toBeDefined()
+  expect(router.beforeHooks.length).toBe(1)
 
   // Now unsync vuex-router-sync
   unsync()
 
   // Ensure router unhooked, store-unwatched, module unregistered
-  expect(router.afterHooks.length).toBe(0)
+  expect(router.beforeHooks.length).toBe(0)
   expect(store._watcherVm).toBeUndefined()
   expect(store.state[moduleName]).toBeUndefined()
 


### PR DESCRIPTION
When using `vuex-router-sync` to get the value of the route from the store on `router.beforeEach` hook, it gives the previous route instead. 

To reproduce the issue:
- https://codesandbox.io/s/vue-router-vuex-lrlcq
- You could see that the route given from `$store.state.route` is different from the `to` route on `router.beforeEach` hook.
- Also, play around with switching from "Home" to "About" and vice versa.
- My expectation is that both values from `$store.state.route` and `to` should sync and be the same.

Although I am not entirely sure why `afterEach` was used initially to sync the routes to the store, in my opinion `beforeEach` should've been used so that it covers before hooks as well. Also, to my understanding, by the time it reaches the component or other stores, it should be already synced just like how it was done with `afterEach` previously. 

That being said, do let me know if this is ok and covers the initial use cases. Thank you.