### PR TITLE
Don`t commit to vuex for failure transition

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,11 +53,16 @@ export function sync(
   )
 
   // sync store on router navigation
-  const afterEachUnHook = router.afterEach((to, from) => {
+  const afterEachUnHook = router.afterEach((to, from, failure) => {
     if (isTimeTraveling) {
       isTimeTraveling = false
       return
     }
+
+    if (failure) {
+        return;
+    }
+
     currentPath = to.fullPath
     store.commit(moduleName + '/ROUTE_CHANGED', { to, from })
   })


### PR DESCRIPTION
Third argument in router hook may has Error for rollback transition. If transition is not success, that router state not changed (revert). Add prevent commit to vuex store for this case.